### PR TITLE
oidc-authorizer: listen on all available interfaces

### DIFF
--- a/oidc-authorizer/cmd/oidc-authorizer/main.go
+++ b/oidc-authorizer/cmd/oidc-authorizer/main.go
@@ -82,5 +82,5 @@ func main() {
 	})
 
 	logrus.Info("Listening")
-	logrus.Fatal(http.ListenAndServe("127.0.0.1:5556", nil))
+	logrus.Fatal(http.ListenAndServe(":5556", nil))
 }


### PR DESCRIPTION
The ready probe uses the host address (10.0.0.0/24).