### PR TITLE
templates/gateway: fix image-builder host address

### DIFF
--- a/templates/gateway.yml
+++ b/templates/gateway.yml
@@ -63,8 +63,8 @@ objects:
               - endpoint:
                   address:
                     socket_address:
-                      address: image-builder.image-builder-community-stage.svc.cluster.local
-                      port_value: 8080
+                      address: image-builder-community-service.image-builder-community-stage.svc.cluster.local
+                      port_value: 8000
 
         ### Listeners ###
         listeners:


### PR DESCRIPTION
Use the service generated by clowder.