### PR TITLE
templates/gateway: use internal_only_headers

### DIFF
--- a/templates/gateway.yml
+++ b/templates/gateway.yml
@@ -125,9 +125,9 @@ objects:
                   - name: api
                     request_headers_to_remove:
                     - x-rh-identity
-                    - x-fedora-identity
                     response_headers_to_remove:
                     - x-rh-identity
+                    internal_only_headers:
                     - x-fedora-identity
                     domains:
                     - "*"


### PR DESCRIPTION
The fedora headers are still required by other services down the line, so mark them as internal.