### PR TITLE
templates/gateway: fix envoy proxy command

### DIFF
--- a/templates/gateway.yml
+++ b/templates/gateway.yml
@@ -211,7 +211,6 @@ objects:
         - name: community-gateway
           image: "${ENVOYPROXY_IMAGE_NAME}:${ENVOYPROXY_IMAGE_TAG}"
           command:
-          - /usr/bin/envoy
           - --config-path
           - /configs/envoy/config.yaml
           ports:


### PR DESCRIPTION
The entrypoint is `envoy`, so just specify the options.