### PR TITLE
templates/gateway: the command needs to be in there

### DIFF
--- a/templates/gateway.yml
+++ b/templates/gateway.yml
@@ -211,6 +211,7 @@ objects:
         - name: community-gateway
           image: "${ENVOYPROXY_IMAGE_NAME}:${ENVOYPROXY_IMAGE_TAG}"
           command:
+          - envoy
           - --config-path
           - /configs/envoy/config.yaml
           ports:


### PR DESCRIPTION
`Command` does override the entrypoint, but don't use the absolute path.