### PR TITLE
Revert "templates/gateway: use internal listener..."

### DIFF
--- a/templates/gateway.yml
+++ b/templates/gateway.yml
@@ -22,12 +22,8 @@ objects:
           pipe:
             path: /sockets/admin.socket
 
-      bootstrap_extensions:
-      - name: envoy.bootstrap.internal_listener
-        typed_config:
-          "@type": type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener
-
       static_resources:
+
         ### Clusters ###
         clusters:
         # This backend is used to send metrics and probe requests to the admin endpoint.
@@ -43,18 +39,6 @@ objects:
                   address:
                     pipe:
                       path: /sockets/admin.socket
-
-        - name: api-listener
-          connect_timeout: 2s
-          type: STRICT_DNS
-          load_assignment:
-            cluster_name: api-listener
-            endpoints:
-            - lb_endpoints:
-              - endpoint:
-                  address:
-                    envoy_internal_address:
-                      server_listener_name: api-listener
 
         - name: ext_fedora_auth
           connect_timeout: 2s
@@ -119,63 +103,6 @@ objects:
                   typed_config:
                     "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
-        - name: api-listener
-          internal_listener: {}
-          filter_chains:
-            filters:
-            - name: envoy.filters.network.http_connection_manager
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                access_log:
-                - name: envoy.access_loggers.file
-                  typed_config:
-                    "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-                    path: /dev/stdout
-                stat_prefix: api-listener
-                route_config:
-                  name: api-listener
-                  virtual_hosts:
-                  - name: api
-                    domains:
-                    - "*"
-                    # Remove these headers in case someone adds them to the response
-                    response_headers_to_remove:
-                    - x-rh-identity
-                    - x-fedora-identity
-                    routes:
-                    - match:
-                        prefix: /api/image-builder
-                      route:
-                        cluster: image-builder
-                        timeout: 30s
-                http_filters:
-                # Remove any identity headers cheeky clients might try to add
-                - name: envoy.filters.http.header_mutation
-                  typed_config:
-                    "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
-                    mutations:
-                      request_mutations:
-                      - remove: x-rh-identity
-                      - remove: x-fedora-identity
-
-                - name: envoy.filters.http.ext_authz
-                  typed_config:
-                    "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
-                    http_service:
-                      server_uri:
-                        uri: 127.0.0.1:5556
-                        cluster: ext_fedora_auth
-                        timeout: 2s
-                      authorization_response:
-                        allowed_upstream_headers:
-                          patterns:
-                          - exact: x-fedora-identity
-
-                - name: envoy.filters.http.router
-                  typed_config:
-                    "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-
-
         - name: ingress
           address:
             socket_address:
@@ -204,18 +131,36 @@ objects:
                     - x-fedora-identity
                     routes:
                     - match:
-                        prefix: /api
+                        prefix: /api/image-builder
                       route:
-                        cluster: api-listener
+                        cluster: image-builder
                         auto_host_rewrite: true
                         timeout: 30s
-                    - match:
-                        prefix: /
-                      redirect:
-                        https_redirect: true
-                        host_redirect: osbuild.org
-                        path_redirect: /docs/service/fedora-console
+
+
                 http_filters:
+                # Remove any identity headers cheeky clients might try to add
+                - name: envoy.filters.http.header_mutation
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.header_mutation.v3.HeaderMutation
+                    mutations:
+                      request_mutations:
+                      - remove: x-rh-identity
+                      - remove: x-fedora-identity
+
+                - name: envoy.filters.http.ext_authz
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+                    http_service:
+                      server_uri:
+                        uri: 127.0.0.1:5556
+                        cluster: ext_fedora_auth
+                        timeout: 2s
+                      authorization_response:
+                        allowed_upstream_headers:
+                          patterns:
+                          - exact: x-fedora-identity
+
                 - name: envoy.filters.http.router
                   typed_config:
                     "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router


### PR DESCRIPTION
This reverts commit 550581b387c4154c747a7198fd605a8edb1f0703.

Using the internal listener with 2 connection managers is tricky, as the request needs to be 'upgraded' again to an HTTP CONNECT request, which is only possible with http2 in envoy.