### PR TITLE
oidc-authorizer: add token introspection

### DIFF
--- a/oidc-authorizer/cmd/oidc-authorizer/main.go
+++ b/oidc-authorizer/cmd/oidc-authorizer/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/osbuild/community-gateway/oidc-authorizer/internal/config"
@@ -13,6 +15,14 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 )
+
+// https://datatracker.ietf.org/doc/rfc7662/
+type IntrospectionResponse struct {
+	Active   bool   `json:"active"`
+	ClientID string `json:"client_id"`
+	Username string `json:"username"`
+	Scope    string `json:"scope"`
+}
 
 func main() {
 	conf := config.Config{}
@@ -50,22 +60,74 @@ func main() {
 			AccessToken: tokenData[1],
 			TokenType:   "Bearer",
 		}
-		userInfo, err := provider.UserInfo(ctx, oauth2.StaticTokenSource(oauth2Token))
-		if err != nil {
-			logrus.Errorf("Failed to fetch user info: %v", err)
-			http.Error(w, fmt.Sprintf("Failed to get userinfo: %v", err), http.StatusInternalServerError)
-			return
+
+		var idHeader identity.Identity
+		// fallback to userinfo if client id/client secret not specified
+		if conf.IntrospectURL == "" {
+			userInfo, err := provider.UserInfo(ctx, oauth2.StaticTokenSource(oauth2Token))
+			if err != nil {
+				logrus.Errorf("Failed to fetch user info: %v", err)
+				http.Error(w, fmt.Sprintf("Failed to get userinfo: %v", err), http.StatusInternalServerError)
+				return
+			}
+
+			if userInfo.Subject == "" {
+				logrus.Warning("User with empty subject")
+				http.Error(w, "UserInfo header has empty subject", http.StatusInternalServerError)
+				return
+			}
+			idHeader = identity.Identity{
+				User: userInfo.Subject,
+			}
+		} else {
+			//
+			body := url.Values{}
+			body.Set("client_id", conf.ClientID)
+			body.Set("client_secret", conf.ClientSecret)
+
+			req, err := http.NewRequest("POST", conf.IntrospectURL, strings.NewReader(body.Encode()))
+			if err != nil {
+				logrus.Errorf("Failed to create a new token introspection request: %v", err)
+				http.Error(w, fmt.Sprintf("Failed to introspect token: %v", err), http.StatusInternalServerError)
+				return
+			}
+
+			req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+			query := req.URL.Query()
+			query.Add("token", oauth2Token.AccessToken)
+			req.URL.RawQuery = query.Encode()
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				logrus.Errorf("Failed to create a new token introspection request: %v", err)
+				http.Error(w, fmt.Sprintf("Failed to introspect token: %v", err), http.StatusInternalServerError)
+				return
+			}
+
+			if resp.StatusCode == http.StatusUnauthorized {
+				http.Error(w, fmt.Sprintf("Introspection returned 401: %v", err), http.StatusUnauthorized)
+				return
+			}
+
+			if resp.StatusCode != http.StatusOK {
+				logrus.Errorf("Introspection returned unexected status : %d", resp.StatusCode)
+				http.Error(w, fmt.Sprintf("Failed to introspect token: %v", err), http.StatusInternalServerError)
+				return
+			}
+
+			var introResp IntrospectionResponse
+			err = json.NewDecoder(resp.Body).Decode(&introResp)
+			if err != nil {
+				logrus.Errorf("Failed to parse token introspection response: %v", err)
+				http.Error(w, fmt.Sprintf("Failed to introspect token: %v", err), http.StatusInternalServerError)
+				return
+			}
+
+			idHeader = identity.Identity{
+				User: introResp.Username,
+			}
 		}
 
-		if userInfo.Subject == "" {
-			logrus.Warning("User with empty subject")
-			http.Error(w, "UserInfo header has empty subject", http.StatusInternalServerError)
-			return
-		}
-
-		idHeader := identity.Identity{
-			User: userInfo.Subject,
-		}
 		idHB64, err := idHeader.Base64()
 		if err != nil {
 			logrus.Errorf("Failed to create identity header: %v", err)

--- a/oidc-authorizer/internal/config/config.go
+++ b/oidc-authorizer/internal/config/config.go
@@ -7,10 +7,11 @@ import (
 )
 
 type Config struct {
-	Provider     string `env:"PROVIDER"`
-	ClientID     string `env:"CLIENT_ID"`
-	ClientSecret string `env:"CLIENT_SECRET"`
-	Scopes       string `env:"SCOPES"`
+	Provider      string `env:"PROVIDER"`
+	ClientID      string `env:"CLIENT_ID"`
+	ClientSecret  string `env:"CLIENT_SECRET"`
+	IntrospectURL string `env:"TOKEN_INTROSPECTION_URL"`
+	Scopes        string `env:"SCOPES"`
 }
 
 var ErrMissingEnvTag = errors.New("missing 'env' tag in config field")


### PR DESCRIPTION
Adds token introspection based on https://datatracker.ietf.org/doc/rfc7662/

also see https://www.oauth.com/oauth2-servers/token-introspection-endpoint/