### PR TITLE
README: remove mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ curl -H "authorization: Bearer $AT" localhost:10000/
 ### Project
 
  * **Website**: <https://www.osbuild.org>
- * **matrix**: https://matrix.to/#/#image-builder:fedoraproject.org
-*  **Mailing List**: image-builder@redhat.com
+ * **Bug Tracker**: <https://github.com/osbuild/community-gateway/issues>
+ * **Discussions**: <https://github.com/orgs/osbuild/discussions>
+ * **Matrix**: [#image-builder on fedoraproject.org](https://matrix.to/#/#image-builder:fedoraproject.org)
+ * **Changelog**: <https://github.com/osbuild/community-gateway/releases>
 
 #### Contributing
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ curl -H "authorization: Bearer $AT" localhost:10000/
 
 #### Contributing
 
-Please refer to the [developer guide](https://www.osbuild.org/guides/developer-guide/index.html) to learn about our workflow, code style and more.
+Please refer to the [developer guide](https://osbuild.org/docs/developer-guide/index) to learn about our workflow, code style and more.
 
 ### License:
 


### PR DESCRIPTION
The mailing list was sunset by the IT department and was rarely used, so we'll replace it with matrix & discussions.