### PR TITLE
templates: fix apiVersion

### DIFF
--- a/templates/gateway.yml
+++ b/templates/gateway.yml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: community-gateway


### PR DESCRIPTION
Latest oc 4.17 requires an update to apiVersion.
This fixes the tests in github actions.